### PR TITLE
fix: add Windows support using pexpect.PopenSpawn fallback

### DIFF
--- a/terminal_mcp/pty_session.py
+++ b/terminal_mcp/pty_session.py
@@ -1,7 +1,9 @@
-"""PTY session: wraps pexpect.spawn with a background reader thread and optional pyte screen."""
+"""PTY session: wraps pexpect.spawn (or PopenSpawn on Windows) with a background reader thread and optional pyte screen."""
 
+import os
 import re
 import signal
+import sys
 import threading
 import time
 import uuid
@@ -9,6 +11,11 @@ from typing import Optional
 
 import pexpect
 import pyte
+
+IS_WINDOWS = sys.platform == "win32"
+
+if IS_WINDOWS:
+    from pexpect.popen_spawn import PopenSpawn
 
 from terminal_mcp.output_buffer import strip_ansi, detect_prompt
 
@@ -72,13 +79,21 @@ class PTYSession:
         self._last_exit_code: Optional[int] = None
         self._command_state: str = "idle"  # "idle" | "prompt" | "running" | "output"
 
-        # Spawn the PTY process via pexpect
-        self.process = pexpect.spawn(
-            command,
-            dimensions=(rows, cols),
-            encoding=None,   # binary mode – we decode manually
-            timeout=None,
-        )
+        self._is_windows = IS_WINDOWS
+
+        if IS_WINDOWS:
+            self.process = PopenSpawn(
+                command,
+                encoding=None,
+                timeout=None,
+            )
+        else:
+            self.process = pexpect.spawn(
+                command,
+                dimensions=(rows, cols),
+                encoding=None,   # binary mode – we decode manually
+                timeout=None,
+            )
 
         # Stream buffer: bytes accumulated by the background reader
         self._buffer: bytearray = bytearray()
@@ -250,8 +265,13 @@ class PTYSession:
         return len(password.encode()) + 1  # +1 for \r
 
     def resize(self, rows: int, cols: int) -> None:
-        """Resize the PTY window. Sends SIGWINCH to the child process."""
-        self.process.setwinsize(rows, cols)
+        """Resize the PTY window. Sends SIGWINCH to the child process.
+
+        On Windows (PopenSpawn), PTY resize is not supported — only the
+        internal pyte screen dimensions are updated.
+        """
+        if not self._is_windows:
+            self.process.setwinsize(rows, cols)
         self.rows = rows
         self.cols = cols
         self._screen.resize(rows, cols)
@@ -534,6 +554,8 @@ class PTYSession:
     def _is_alive(self) -> bool:
         """Check if process is alive, returning False if already reaped."""
         try:
+            if self._is_windows:
+                return self.process.proc.poll() is None
             return self.process.isalive()
         except Exception:
             return False
@@ -542,7 +564,8 @@ class PTYSession:
         """
         Gracefully shut down the session.
 
-        Sequence: EOF → 2s wait → SIGHUP → 2s wait → SIGKILL.
+        Unix sequence: EOF → 2s wait → SIGHUP → 2s wait → SIGKILL.
+        Windows sequence: EOF → 2s wait → terminate → 2s wait → kill.
         Returns the exit status code (or None if unavailable).
         """
         try:
@@ -558,7 +581,10 @@ class PTYSession:
 
         if self._is_alive():
             try:
-                self.process.kill(signal.SIGHUP)
+                if self._is_windows:
+                    self.process.proc.terminate()
+                else:
+                    self.process.kill(signal.SIGHUP)
             except Exception:
                 pass
             for _ in range(20):
@@ -573,9 +599,13 @@ class PTYSession:
                 pass
             time.sleep(0.5)
 
-        exit_status = self.process.exitstatus
+        if self._is_windows:
+            exit_status = self.process.proc.returncode
+        else:
+            exit_status = self.process.exitstatus
         try:
-            self.process.close(force=True)
+            if not self._is_windows:
+                self.process.close(force=True)
         except Exception:
             pass
         return exit_status
@@ -592,6 +622,8 @@ class PTYSession:
     @property
     def pid(self) -> int:
         """PID of the spawned process."""
+        if self._is_windows:
+            return self.process.proc.pid
         return self.process.pid
 
     @property

--- a/tests/test_phase1.py
+++ b/tests/test_phase1.py
@@ -504,7 +504,7 @@ class TestOSC133Parsing:
         mock_session._osc133_supported = False
         mock_session.read_stream.return_value = ("out", 3, False)
 
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             handle_session_read(mock_manager, {"session_id": "abcd1234"})
         )
         assert "osc133" not in result


### PR DESCRIPTION
## Summary

- Fixes #16 — `module 'pexpect' has no attribute 'spawn'` on Windows
- On Windows, `pexpect.spawn` is unavailable (it requires Unix PTYs). This adds a fallback to `pexpect.popen_spawn.PopenSpawn` with compatibility shims for the API differences
- All 235 existing tests continue to pass on Unix

## Changes

**`terminal_mcp/pty_session.py`:**
- Added platform detection (`sys.platform == "win32"`) and conditional import of `PopenSpawn`
- On Windows, spawns processes via `PopenSpawn` instead of `pexpect.spawn`
- `_is_alive()` — uses `proc.poll()` instead of `isalive()` on Windows
- `resize()` — skips `setwinsize()` on Windows (not supported by PopenSpawn); internal pyte screen dimensions are still updated
- `close()` — uses `proc.terminate()` instead of `SIGHUP`, and `proc.returncode` instead of `exitstatus` on Windows
- `pid` property — reads from `proc.pid` on Windows

## Limitations

- `PopenSpawn` does not allocate a real PTY, so terminal resize (`SIGWINCH`) is a no-op on Windows
- Some PTY-specific features (alt-screen detection, OSC 133) may behave differently without a real PTY

## Test plan

- [x] All 235 existing tests pass on Unix (no regressions)
- [ ] Manual verification on Windows with `cmd.exe` and `powershell.exe`

---
_Generated by [Claude Code](https://claude.ai/code/session_0164KK2Cx8Gd5nNrWw8EpN9r)_