### PR TITLE
fix: add dangerous-command safety gate to session_exec

### DIFF
--- a/terminal_mcp/tools/session.py
+++ b/terminal_mcp/tools/session.py
@@ -396,6 +396,18 @@ async def handle_session_exec(manager: "SessionManager", arguments: dict) -> dic
             "error": {"type": "validation_error", "message": "'exec' is required"},
         }
 
+    if not arguments.get("confirmed", False):
+        from terminal_mcp.safety import check_dangerous
+        danger_reason = check_dangerous(exec_cmd)
+        if danger_reason:
+            return {
+                "success": False,
+                "requires_confirmation": True,
+                "command": exec_cmd,
+                "reason": danger_reason,
+                "message": "This command matches a dangerous pattern. Resend with confirmed=true to execute.",
+            }
+
     shell = arguments.get("command", "bash")
     timeout = float(arguments.get("timeout", 5.0))
     rows = arguments.get("rows", 24)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -693,3 +693,30 @@ class TestHandleSessionExec:
         assert result["success"] is True
         assert result["truncated"] is True
         assert "[output truncated]" in result["output"]
+
+    @pytest.mark.asyncio
+    async def test_exec_blocks_dangerous_command(self, mock_manager):
+        from terminal_mcp.tools.session import handle_session_exec
+        result = await handle_session_exec(
+            mock_manager, {"exec": "rm -rf /important"}
+        )
+        assert result["success"] is False
+        assert result["requires_confirmation"] is True
+        assert result["command"] == "rm -rf /important"
+        mock_manager.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_exec_allows_dangerous_command_when_confirmed(self, mock_manager, mock_session):
+        from terminal_mcp.tools.session import handle_session_exec
+        mock_manager.create.return_value = mock_session
+        mock_session.read_stream.side_effect = [
+            ("$ ", 2, True),
+            ("removed\n$ ", 11, True),
+        ]
+        mock_session.send.return_value = 15
+
+        result = await handle_session_exec(
+            mock_manager, {"exec": "rm -rf /important", "confirmed": True}
+        )
+        assert result["success"] is True
+        mock_manager.create.assert_called_once()


### PR DESCRIPTION
## Summary

- Fixes #19 — `session_exec` was the only tool handler that bypassed the dangerous-command safety gate
- Added `check_dangerous()` call before command execution, matching the existing pattern in `session_send` and `session_interact`
- Added `confirmed` parameter support to allow bypassing the gate when explicitly confirmed

## Changes

- **`terminal_mcp/tools/session.py`** — Added safety gate check in `handle_session_exec` before spawning the session
- **`tests/test_tools.py`** — Added two new tests:
  - `test_exec_blocks_dangerous_command` — verifies dangerous commands are blocked
  - `test_exec_allows_dangerous_command_when_confirmed` — verifies `confirmed=true` bypasses the gate

## Test plan

- [x] All 238 tests pass
- [x] New tests verify both blocked and confirmed-bypass scenarios
- [x] Dangerous command (`rm -rf /important`) correctly returns `requires_confirmation`
- [x] `confirmed=true` allows execution

---
_Generated by [Claude Code](https://claude.ai/code/session_0164KK2Cx8Gd5nNrWw8EpN9r)_