### PR TITLE
fix: use absolute buffer position in session_wait_for

### DIFF
--- a/terminal_mcp/tools/session.py
+++ b/terminal_mcp/tools/session.py
@@ -704,11 +704,13 @@ async def handle_session_wait_for(manager: "SessionManager", arguments: dict) ->
     strip_ansi_output = arguments.get("strip_ansi", True)
 
     try:
+        start_pos = await asyncio.to_thread(session.current_buffer_end)
         output, bytes_read, matched, prompt_detected = await asyncio.to_thread(
             session.read_until_pattern,
             pattern=pattern,
             timeout=timeout,
             strip_ansi_output=strip_ansi_output,
+            start_position=start_pos,
         )
 
         truncation = arguments.get("truncation")

--- a/tests/test_phase1.py
+++ b/tests/test_phase1.py
@@ -125,6 +125,23 @@ class TestHandleSessionWaitFor:
         assert "is_alive" in result
 
     @pytest.mark.asyncio
+    async def test_wait_for_uses_absolute_start_position(self, mock_manager, mock_session):
+        """session_wait_for must snapshot current_buffer_end and pass it as start_position."""
+        from terminal_mcp.tools.session import handle_session_wait_for
+        mock_manager.get.return_value = mock_session
+        mock_session.current_buffer_end.return_value = 500
+        mock_session.read_until_pattern.return_value = ("output\n$ ", 9, True, True)
+
+        result = await handle_session_wait_for(
+            mock_manager,
+            {"session_id": "abcd1234", "pattern": r"\$"}
+        )
+        assert result["success"] is True
+        mock_session.current_buffer_end.assert_called_once()
+        call_kwargs = mock_session.read_until_pattern.call_args[1]
+        assert call_kwargs["start_position"] == 500
+
+    @pytest.mark.asyncio
     async def test_truncation_applied(self, mock_manager, mock_session):
         from terminal_mcp.tools.session import handle_session_wait_for
         mock_manager.get.return_value = mock_session
@@ -142,6 +159,7 @@ class TestHandleSessionWaitFor:
     async def test_passes_timeout_and_strip_ansi(self, mock_manager, mock_session):
         from terminal_mcp.tools.session import handle_session_wait_for
         mock_manager.get.return_value = mock_session
+        mock_session.current_buffer_end.return_value = 0
         mock_session.read_until_pattern.return_value = ("out", 3, True, False)
 
         await handle_session_wait_for(
@@ -152,6 +170,7 @@ class TestHandleSessionWaitFor:
             pattern=r"out",
             timeout=10.0,
             strip_ansi_output=False,
+            start_position=0,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fixes #20 — `session_wait_for` used the relative buffer code path in `read_until_pattern`, which breaks after a buffer trim
- Now snapshots `current_buffer_end()` and passes it as `start_position`, matching what `session_interact` already does correctly

## Root Cause

When `read_until_pattern` is called without `start_position` (the default), it takes a local `start_pos` snapshot that becomes invalid after the reader thread trims the buffer. The absolute anchor mechanism (`_total_bytes_written`) already exists and works correctly — `session_wait_for` just wasn't using it.

## Changes

- **`terminal_mcp/tools/session.py`** — Added `current_buffer_end()` snapshot before `read_until_pattern` call, passed as `start_position`
- **`tests/test_phase1.py`** — Added test verifying `start_position` is passed; updated existing test to expect the new parameter

## Test plan

- [x] All 237 tests pass
- [x] New test verifies `current_buffer_end()` is called and its value passed as `start_position`

---
_Generated by [Claude Code](https://claude.ai/code/session_0164KK2Cx8Gd5nNrWw8EpN9r)_