### PR TITLE
perf: release lock during session spawn

### DIFF
--- a/terminal_mcp/session_manager.py
+++ b/terminal_mcp/session_manager.py
@@ -51,18 +51,26 @@ class SessionManager:
                 raise RuntimeError(
                     f"Maximum number of sessions ({self.config.max_sessions}) reached"
                 )
-            session = PTYSession(
-                command=command,
-                label=label,
-                rows=rows,
-                cols=cols,
-                enable_snapshot=enable_snapshot,
-                scrollback_lines=scrollback_lines,
-                max_buffer_bytes=self.config.max_buffer_bytes,
-            )
-            # Store optional per-session idle timeout
-            if idle_timeout is not None:
-                session._idle_timeout_override = idle_timeout
+
+        session = PTYSession(
+            command=command,
+            label=label,
+            rows=rows,
+            cols=cols,
+            enable_snapshot=enable_snapshot,
+            scrollback_lines=scrollback_lines,
+            max_buffer_bytes=self.config.max_buffer_bytes,
+        )
+
+        if idle_timeout is not None:
+            session._idle_timeout_override = idle_timeout
+
+        with self._lock:
+            if len(self._sessions) >= self.config.max_sessions:
+                session.close()
+                raise RuntimeError(
+                    f"Maximum number of sessions ({self.config.max_sessions}) reached"
+                )
             self._sessions[session.session_id] = session
             logger.info("Session %s created: %s (pid=%s)", session.session_id, command, session.pid)
             return session

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,6 +1,7 @@
 """Tests for SessionManager."""
 
 import sys
+import threading
 import time
 import pytest
 from unittest.mock import patch, MagicMock
@@ -102,3 +103,86 @@ class TestSessionManagerCreate:
         assert len(manager.list_sessions()) == 2
         manager.close_all()
         assert len(manager.list_sessions()) == 0
+
+
+class TestSessionManagerLockDuringSpawn:
+    """Issue #22: create() must not hold the lock during PTYSession construction."""
+
+    def test_lock_not_held_during_pty_construction(self):
+        """Other operations must not be blocked while a session is spawning."""
+        config = TerminalConfig(
+            max_sessions=5,
+            idle_timeout=60,
+            default_rows=24,
+            default_cols=80,
+            read_settle_timeout=0.2,
+            max_output_bytes=10_000,
+            cleanup_interval=9999,
+        )
+        mgr = SessionManager(config)
+
+        spawn_started = threading.Event()
+        lock_acquired = threading.Event()
+
+        original_init = None
+
+        def slow_pty_init(self_pty, *args, **kwargs):
+            spawn_started.set()
+            lock_acquired.wait(timeout=5)
+            original_init(self_pty, *args, **kwargs)
+
+        try:
+            from terminal_mcp.pty_session import PTYSession
+            original_init = PTYSession.__init__
+
+            with patch.object(PTYSession, '__init__', slow_pty_init):
+                create_thread = threading.Thread(
+                    target=lambda: mgr.create(command="/bin/echo hi"),
+                )
+                create_thread.start()
+
+                spawn_started.wait(timeout=5)
+                assert spawn_started.is_set(), "PTYSession init never started"
+
+                acquired = mgr._lock.acquire(timeout=2)
+                if acquired:
+                    lock_acquired.set()
+                    mgr._lock.release()
+                else:
+                    lock_acquired.set()
+                    create_thread.join(timeout=5)
+                    pytest.fail("Lock was held during PTYSession construction")
+
+                create_thread.join(timeout=10)
+        finally:
+            mgr.close_all()
+
+    def test_max_sessions_race_cleans_up(self):
+        """If max_sessions is hit between pre-check and registration, the
+        spawned session is closed and RuntimeError is raised."""
+        config = TerminalConfig(
+            max_sessions=1,
+            idle_timeout=60,
+            default_rows=24,
+            default_cols=80,
+            read_settle_timeout=0.2,
+            max_output_bytes=10_000,
+            cleanup_interval=9999,
+        )
+        mgr = SessionManager(config)
+
+        mock_session = MagicMock()
+        mock_session.session_id = "race-sess"
+
+        def pty_side_effect(*args, **kwargs):
+            mgr._sessions["snuck-in"] = MagicMock()
+            return mock_session
+
+        with patch("terminal_mcp.session_manager.PTYSession", side_effect=pty_side_effect):
+            with pytest.raises(RuntimeError, match="Maximum number of sessions"):
+                mgr.create(command="/bin/echo hi")
+
+            mock_session.close.assert_called_once()
+            assert "race-sess" not in mgr._sessions
+
+        mgr._sessions.clear()


### PR DESCRIPTION
## Summary

- `SessionManager.create()` now constructs `PTYSession` outside the global lock, so concurrent `get`/`close`/`list_sessions` calls aren't blocked during process spawn.
- The lock is held only briefly for the pre-check and the post-spawn registration, with a second `max_sessions` guard to handle the race condition.
- If the race is lost (another session filled the slot during spawn), the already-spawned session is properly closed before raising `RuntimeError`.

## Test plan

- [x] `test_lock_not_held_during_pty_construction` — verifies the lock is acquirable by another thread while PTYSession is being constructed
- [x] `test_max_sessions_race_cleans_up` — verifies that if a session sneaks in during spawn, the new session is closed and the error is raised
- [x] All existing `TestSessionManagerCreate` tests still pass
- [x] Full test suite passes (238 tests)

Fixes #22

---
_Generated by [Claude Code](https://claude.ai/code/session_0164KK2Cx8Gd5nNrWw8EpN9r)_